### PR TITLE
Remove push to main trigger in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,6 @@ on:
   pull_request:
     paths-ignore:
       - 'README.md'
-  push:
-    branches:
-      - main
 
 jobs:
   tests:


### PR DESCRIPTION
# Summary
Now that we have a new workflow that is triggered when code is merged to `main`, we no longer need `ci.yaml` to trigger in the same scenario anymore.