### PR TITLE
Show prom metrics in grafana

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,9 +8,12 @@ services:
     volumes:
       - ./grafana.ini:/etc/grafana-config/grafana.ini
       - ./grafana-dashboard-config.yaml:/etc/grafana/provisioning/dashboards/grafana-dashboard-config.yaml
+      - ./grafana-data-sources.yaml:/etc/grafana/provisioning/datasources/grafana-data-sources.yaml
       - ./grafana-dashboard.json:/etc/grafana/dashboards/grafana-dashboard.json
     ports:
       - "3000:3000"
+    networks:
+      - revwallet_network
 
   prometheus:
     image: prom/prometheus:latest

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -200,7 +200,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "flask_request_duration_seconds_sum{app_name=\"flask-monitoring\"} / flask_request_duration_seconds_count{app_name=\"flask-monitoring\"}",
+          "expr": "flask_request_duration_seconds_sum{app_name=\"$app_name\"} / flask_request_duration_seconds_count{app_name=\"$app_name\"}",
           "interval": "",
           "legendFormat": "{{method}} {{endpoint}}",
           "refId": "A"

--- a/grafana-data-sources.yaml
+++ b/grafana-data-sources.yaml
@@ -1,0 +1,23 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    # Access mode - proxy (server in the UI) or direct (browser in the UI).
+    url: http://prometheus:9090
+    jsonData:
+      httpMethod: POST
+      manageAlerts: true
+      prometheusType: Prometheus
+      prometheusVersion: 2.44.0
+      cacheLevel: 'High'
+      disableRecordingRules: false
+      incrementalQueryOverlapWindow: 10m
+      exemplarTraceIdDestinations:
+        - datasourceUid: revwallet_datasource_id
+          name: traceID
+
+        # Field with external link.
+        - name: traceID
+          url: 'http://grafana:3000/'

--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -6,3 +6,6 @@ scrape_configs:
   - job_name: 'revwallet_api'
     static_configs:
       - targets: ['revwallet_api:5000']
+
+remote_write:
+- url: http://localhost:9090/api/prom/push


### PR DESCRIPTION
# Summary
Now the configuration between Prometheus and Grafana is set up, so metrics from the RevWallet API are shown there.