### PR TITLE
Serve prometheus behind nginx

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,4 +7,4 @@ metrics = PrometheusMetrics(app)
 metrics.info('app_info', 'revwallet', version='v0.2.0')
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/config/grafana/data-sources.yaml
+++ b/config/grafana/data-sources.yaml
@@ -6,7 +6,7 @@ datasources:
     editable: true
     is_default: true
     access: proxy
-    url: http://prometheus:9090
+    url: http://prometheus:9090/prometheus
   - name: Loki
     type: loki
     access: proxy

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -33,7 +33,11 @@ http {
     }
 
     upstream grafana {
-    server grafana:3000;
+        server grafana:3000;
+    }
+
+    upstream prometheus {
+        server prometheus:9090;
     }
 
     server {
@@ -62,6 +66,16 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_pass http://grafana;
+        }
+
+        location /prometheus/ {
+            auth_basic "Restricted Access";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+            proxy_pass http://prometheus;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         error_page 404 /404.html;

--- a/config/prometheus/prometheus.yaml
+++ b/config/prometheus/prometheus.yaml
@@ -8,4 +8,4 @@ scrape_configs:
       - targets: ['revwallet_api:5000']
 
 remote_write:
-- url: http://localhost:9090/api/prom/push
+- url: http://localhost:9090/prometheus/api/prom/push

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,6 +69,8 @@ services:
       - ./config/prometheus/prometheus.yaml:/etc/prometheus/prometheus.yaml
     command:
       - '--config.file=/etc/prometheus/prometheus.yaml'
+      - '--web.external-url=/prometheus/'
+      - '--web.route-prefix=/prometheus/'
     ports:
       - "9090:9090"
     networks:


### PR DESCRIPTION
# Summary
This PR places Prometheus behind Nginx behind basic auth. Prometheus is now served at `revwallet.com/prometheus`.