### PR TITLE
Access services trough reverse proxy only

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -46,7 +46,8 @@ http {
 
     server {
         listen 80;
-        server_name revwallet.com;
+        server_name revwallet.com
+                    127.0.0.1;
 
         location /wallet {
             auth_basic off;

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -28,8 +28,8 @@ http {
 
     # This is required to proxy Grafana Live WebSocket connections.
     map $http_upgrade $connection_upgrade {
-    default upgrade;
-    '' close;
+        default upgrade;
+        '' close;
     }
 
     upstream grafana {
@@ -40,13 +40,17 @@ http {
         server prometheus:9090;
     }
 
+    upstream revwallet_api {
+        server revwallet_api:5000;
+    }
+
     server {
         listen 80;
         server_name revwallet.com;
 
         location /wallet {
             auth_basic off;
-            proxy_pass http://revwallet_api:5000/wallet/;
+            proxy_pass http://revwallet_api/wallet/;
         }
 
         # Admin paths

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,8 @@ services:
     container_name: loki
     volumes:
       - ./config/loki/loki-config.yaml:/etc/loki/local-config.yaml
-    ports:
-      - "3100:3100"
+    # ports:
+    #   - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
     networks:
       - revwallet_network
@@ -24,8 +24,8 @@ services:
     volumes:
       - ./config/alloy/config.alloy:/etc/alloy/config.alloy
       - ./logs/revwallet:/var/log/revwallet
-    ports:
-      - "12345:12345"
+    # ports:
+    #   - "12345:12345"
     command: [
       "run",
       "--server.http.listen-addr=0.0.0.0:12345",
@@ -52,8 +52,8 @@ services:
       - ./config/grafana/provisioning.yaml:/etc/grafana/provisioning/dashboards/provisioning.yaml
       - ./config/grafana/data-sources.yaml:/etc/grafana/provisioning/datasources/data-sources.yaml
       - ./config/grafana/dashboard.json:/etc/grafana/dashboards/dashboard.json
-    ports:
-      - "3000:3000"
+    # ports:
+    #   - "3000:3000"
     networks:
       - revwallet_network
     healthcheck:
@@ -71,8 +71,8 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yaml'
       - '--web.external-url=/prometheus/'
       - '--web.route-prefix=/prometheus/'
-    ports:
-      - "9090:9090"
+    # ports:
+    #   - "9090:9090"
     networks:
       - revwallet_network
     healthcheck:
@@ -89,8 +89,8 @@ services:
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword
       POSTGRES_DB: revwallet
-    ports:
-      - "5432:5432"
+    # ports:
+    #   - "5432:5432"
     volumes:
       - db_data:/var/lib/postgresql/data
     networks:
@@ -121,8 +121,8 @@ services:
       DB_PASSWORD: mypassword
       DB_NAME: revwallet
       DB_HOST: revwallet_db
-    ports:
-      - "5000:5000"
+    # ports:
+    #   - "5000:5000"
     networks:
       - revwallet_network
     links:

--- a/scripts/generate-data
+++ b/scripts/generate-data
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-curl -X GET http://127.0.0.1:5000/wallet/
+curl -L -X GET http://revwallet.com/wallet/
 
 for ((i=1; i<=100; i++))
 do
-  curl -X POST http://127.0.0.1:5000/wallet/ \
+  curl -L -X POST http://revwallet.com/wallet/ \
     -H "Content-Type: application/json" \
     -d '{"owner": "test", "initial_balance": "999.00", "currency": "EUR"}'
 
-  curl -X GET "http://127.0.0.1:5000/wallet/balance/$i"
-  curl -X GET http://127.0.0.1:5000/wallet/
+  curl -L -X GET "http://revwallet.com/wallet/balance/$i"
+  curl -L -X GET http://revwallet.com/wallet/
 done

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,7 +7,7 @@ import requests
 class TestWalletE2E(unittest.TestCase):
 
   def setUp(self):
-    self.base_url = "http://localhost"
+    self.base_url = "http://127.0.0.1"
     self.balance = 900.00
     self.currency = "EUR"
     self.owner = "test"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,7 +7,7 @@ import requests
 class TestWalletE2E(unittest.TestCase):
 
   def setUp(self):
-    self.base_url = "http://revwallet.com"
+    self.base_url = "http://localhost"
     self.balance = 900.00
     self.currency = "EUR"
     self.owner = "test"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,7 +7,7 @@ import requests
 class TestWalletE2E(unittest.TestCase):
 
   def setUp(self):
-    self.base_url = "http://127.0.0.1:5000"
+    self.base_url = "http://revwallet.com"
     self.balance = 900.00
     self.currency = "EUR"
     self.owner = "test"


### PR DESCRIPTION
# Summary
This PR removes the port binding of (almost) all the services required to run the Wallet API. Now, the only port binded is the Nginx port (for now, `80`). Every service should be accessed through the reverse proxy.