### PR TITLE
Run RevWallet on K8s

### DIFF
--- a/config/grafana/dashboard.json
+++ b/config/grafana/dashboard.json
@@ -522,7 +522,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "expr": "process_resident_memory_bytes{job=\"revwallet_api\"}",
+          "expr": "process_resident_memory_bytes{job=\"revwallet-api\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "mem",
@@ -793,7 +793,7 @@
       "targets": [
         {
           "$$hashKey": "object:638",
-          "expr": "rate(process_cpu_seconds_total{job=\"revwallet_api\"}[30s])",
+          "expr": "rate(process_cpu_seconds_total{job=\"revwallet-api\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "cpu",

--- a/config/loki/loki-config.yaml
+++ b/config/loki/loki-config.yaml
@@ -17,7 +17,7 @@ common:
 
 schema_config:
   configs:
-    - from: 2020-10-24
+    - from: 2024-04-01
       store: tsdb
       object_store: filesystem
       schema: v13

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -75,8 +75,8 @@ http {
         server prometheus:9090;
     }
 
-    upstream revwallet_api {
-        server revwallet_api:5000;
+    upstream revwallet-api {
+        server revwallet-api:5000;
     }
 
     server {
@@ -86,7 +86,7 @@ http {
 
         location /wallet {
             auth_basic off;
-            proxy_pass http://revwallet_api/wallet/;
+            proxy_pass http://revwallet-api/wallet/;
         }
 
         # Admin paths

--- a/config/prometheus/prometheus.yaml
+++ b/config/prometheus/prometheus.yaml
@@ -3,9 +3,9 @@ global:
   evaluation_interval:  15s
 
 scrape_configs:
-  - job_name: 'revwallet_api'
+  - job_name: 'revwallet-api'
     static_configs:
-      - targets: ['revwallet_api:5000']
+      - targets: ['revwallet-api:5000']
 
 remote_write:
 - url: http://localhost:9090/prometheus/api/prom/push

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -83,11 +83,11 @@ services:
       retries: 10
       start_period: 40s
 
-  revwallet_db:
+  revwallet-db:
     image: postgres:latest
-    container_name: revwallet_db
+    container_name: revwallet-db
     environment:
-      POSTGRES_USER: myuser
+      POSTGRES_USER: revwallet
       POSTGRES_PASSWORD: mypassword
       POSTGRES_DB: revwallet
     # ports:
@@ -97,19 +97,19 @@ services:
     networks:
       - revwallet_network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d revwallet -U myuser"]
+      test: ["CMD-SHELL", "pg_isready -d revwallet -U revwallet"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-  revwallet_api:
+  revwallet-api:
     image: arthurjguerra18/revwallet:${GITHUB_SHA:-test}
-    container_name: revwallet_api
+    container_name: revwallet-api
     build:
       context: .
       dockerfile: Dockerfile
     depends_on:
-      revwallet_db:
+      revwallet-db:
         condition: service_healthy
       prometheus:
         condition: service_healthy
@@ -118,16 +118,16 @@ services:
       alloy:
         condition: service_started
     environment:
-      DB_USERNAME: myuser
+      DB_USERNAME: revwallet
       DB_PASSWORD: mypassword
       DB_NAME: revwallet
-      DB_HOST: revwallet_db
+      DB_HOST: revwallet-db
     # ports:
     #   - "5000:5000"
     networks:
       - revwallet_network
     links:
-      - revwallet_db
+      - revwallet-db
     volumes:
       - ./logs/revwallet:/var/log/revwallet
 
@@ -145,7 +145,7 @@ services:
     networks:
       - revwallet_network
     depends_on:
-      revwallet_api:
+      revwallet-api:
         condition: service_started
       prometheus:
         condition: service_healthy

--- a/k8s/nginx/values.yaml
+++ b/k8s/nginx/values.yaml
@@ -1,0 +1,36 @@
+image:
+  registry: docker.io
+  repository: bitnami/nginx
+  tag: 1.27.0-debian-12-r5
+  pullPolicy: Always
+
+service:
+  type: NodePort
+  port: 8080
+
+replicaCount: 1
+
+ingress:
+  enabled: true
+  hostname: revwallet.com
+  hosts:
+    - host: revwallet.com
+      paths: []
+    - host: 127.0.0.1
+      paths: [] 
+  tls: false
+
+extraVolumes:
+  - name: nginx-html
+    configMap:
+      name: nginx-html
+  - name: nginx-config
+    configMap:
+      name: nginx-config
+
+extraVolumeMounts:
+  - name: nginx-html
+    mountPath: /opt/bitnami/nginx/html/
+  - name: nginx-config
+    mountPath: /opt/bitnami/nginx/conf/nginx.conf
+    subPath: nginx.conf

--- a/k8s/revwallet-api-chart/.helmignore
+++ b/k8s/revwallet-api-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/revwallet-api-chart/Chart.yaml
+++ b/k8s/revwallet-api-chart/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: revwallet-api-chart
+description: RevWallet Helm Chart
+
+type: application
+version: 0.0.1
+appVersion: "latest"

--- a/k8s/revwallet-api-chart/templates/NOTES.txt
+++ b/k8s/revwallet-api-chart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "revwallet-api-chart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "revwallet-api-chart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "revwallet-api-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "revwallet-api-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/k8s/revwallet-api-chart/templates/_helpers.tpl
+++ b/k8s/revwallet-api-chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "revwallet-api-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "revwallet-api-chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "revwallet-api-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "revwallet-api-chart.labels" -}}
+helm.sh/chart: {{ include "revwallet-api-chart.chart" . }}
+{{ include "revwallet-api-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "revwallet-api-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "revwallet-api-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "revwallet-api-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "revwallet-api-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/revwallet-api-chart/templates/deployment.yaml
+++ b/k8s/revwallet-api-chart/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "revwallet-api-chart.fullname" . }}
+  labels:
+    {{- include "revwallet-api-chart.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "revwallet-api-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "revwallet-api-chart.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "revwallet-api-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DB_USERNAME
+              value: {{ .Values.env.DB_USERNAME }}
+            - name: DB_PASSWORD
+              value: {{ .Values.env.DB_PASSWORD }}
+            - name: DB_NAME
+              value: {{ .Values.env.DB_NAME }}
+            - name: DB_HOST
+              value: {{ .Values.env.DB_HOST }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s/revwallet-api-chart/templates/hpa.yaml
+++ b/k8s/revwallet-api-chart/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "revwallet-api-chart.fullname" . }}
+  labels:
+    {{- include "revwallet-api-chart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "revwallet-api-chart.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/k8s/revwallet-api-chart/templates/ingress.yaml
+++ b/k8s/revwallet-api-chart/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "revwallet-api-chart.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "revwallet-api-chart.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k8s/revwallet-api-chart/templates/pvc.yaml
+++ b/k8s/revwallet-api-chart/templates/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.persistentVolumeClaim.name }}
+  labels:
+    {{- include "revwallet-api-chart.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistentVolumeClaim.accessModes | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolumeClaim.size | default "1Gi" }}
+  {{- if .Values.persistentVolumeClaim.storageClass }}
+  storageClassName: {{ .Values.persistentVolumeClaim.storageClass }}
+  {{- end }}

--- a/k8s/revwallet-api-chart/templates/service.yaml
+++ b/k8s/revwallet-api-chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "revwallet-api-chart.fullname" . }}
+  labels:
+    {{- include "revwallet-api-chart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "revwallet-api-chart.selectorLabels" . | nindent 4 }}

--- a/k8s/revwallet-api-chart/templates/serviceaccount.yaml
+++ b/k8s/revwallet-api-chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "revwallet-api-chart.serviceAccountName" . }}
+  labels:
+    {{- include "revwallet-api-chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/k8s/revwallet-api-chart/templates/tests/test-connection.yaml
+++ b/k8s/revwallet-api-chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "revwallet-api-chart.fullname" . }}-test-connection"
+  labels:
+    {{- include "revwallet-api-chart.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "revwallet-api-chart.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/k8s/revwallet-api-chart/values.yaml
+++ b/k8s/revwallet-api-chart/values.yaml
@@ -1,0 +1,78 @@
+replicaCount: 1
+
+image:
+  repository: arthurjguerra18/revwallet
+  pullPolicy: Always
+  tag: "v0.3.0"
+
+imagePullSecrets: []
+nameOverride: "revwallet-api"
+fullnameOverride: "revwallet-api"
+
+env:
+  DB_USERNAME: revwallet
+  DB_PASSWORD: mypassword
+  DB_NAME: revwallet
+  DB_HOST: revwallet-db.revwallet-dev.svc.cluster.local
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: "revwallet-api-sa"
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: NodePort
+  port: 5000
+
+ingress:
+  enabled: false
+
+resources:
+  limits:
+    cpu: 100m
+  requests:
+    cpu: 100m
+
+livenessProbe:
+  httpGet:
+    path: /wallet/
+    port: http
+readinessProbe:
+  httpGet:
+    path: /wallet/
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+persistentVolumeClaim:
+  name: revwallet-api-log-volume-claim
+  accessModes: ReadWriteOnce
+  size: 1Gi
+  storageClass: ""  # set to default
+
+volumes: 
+  - name: revwallet-api-log-volume
+    persistentVolumeClaim:
+      claimName: revwallet-api-log-volume-claim
+
+volumeMounts:
+  - name: revwallet-api-log-volume
+    mountPath: /var/log/revwallet
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/k8s/revwallet-db/configmap.yaml
+++ b/k8s/revwallet-db/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: revwallet-db-secret
+  labels:
+    app: revwallet-db
+data:
+  POSTGRES_DB: revwallet
+  POSTGRES_USER: revwallet
+  POSTGRES_PASSWORD: mypassword

--- a/k8s/revwallet-db/deployment.yaml
+++ b/k8s/revwallet-db/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: revwallet-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: revwallet-db
+  template:
+    metadata:
+      labels:
+        app: revwallet-db
+    spec:
+      containers:
+        - name: revwallet-db
+          image: 'postgres:latest'
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: revwallet-db-secret
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: revwallet-db-data
+      volumes:
+        - name: revwallet-db-data
+          persistentVolumeClaim:
+            claimName: revwallet-volume-claim

--- a/k8s/revwallet-db/pv-claim.yaml
+++ b/k8s/revwallet-db/pv-claim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: revwallet-volume-claim
+  labels:
+    app: revwallet-db
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/revwallet-db/pv.yaml
+++ b/k8s/revwallet-db/pv.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: revwallet-db-volume
+  labels:
+    type: local
+    app: revwallet-db
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: /data/postgresql

--- a/k8s/revwallet-db/service.yaml
+++ b/k8s/revwallet-db/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: revwallet-db
+  labels:
+    app: revwallet-db
+spec:
+  type: NodePort
+  ports:
+    - port: 5432
+  selector:
+    app: revwallet-db


### PR DESCRIPTION
# Summary
This PR allows the RevWallet API to run on K8s behind Nginx:
- Implements the `helm` chart of the API
- Adds the K8s resources to deploy the PostgreSQL DB
- Adds the values.yaml to deploy Nginx and configure it properly
- Update instructions in README

Note: observability tools do not work on K8s at the moment.