### PR TITLE
Configure concurrency build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   tests:
     secrets: inherit


### PR DESCRIPTION
This PR allows the build workflow to run only once at a time.