### PR TITLE
Use publish api chart in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ setup-helm:
 	helm repo add bitnami https://charts.bitnami.com/bitnami
 	helm repo add grafana https://grafana.github.io/helm-charts
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+	helm repo add revwallet-api https://arthurjguerra.github.io/revwallet
 	helm repo update
 
 terminate:
@@ -74,7 +75,7 @@ api:
 	kubectl -n revwallet-dev wait --timeout=5m --for=condition=Ready pod -l app=revwallet-db
 
 	helm repo update
-	helm -n revwallet-dev upgrade --install --values helm/revwallet-api/values.yaml revwallet-api charts/revwallet-api
+	helm -n revwallet-dev upgrade --install --values helm/revwallet-api/values.yaml revwallet-api revwallet-api/revwallet-api
 
 prometheus:
 	helm repo update prometheus-community

--- a/helm/revwallet-api/values.yaml
+++ b/helm/revwallet-api/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: arthurjguerra18/revwallet
-  tag: "v0.4.0"
+  tag: "v0.5.0"
 
 env:
   DB_USERNAME: revwallet


### PR DESCRIPTION
This PR changes the RevWallet API chart used by `Makefile`. Instead of pointing to the local chart directory, it uses the published one.