### PR TITLE
Add publish helm chart badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Publish](https://github.com/arthurjguerra/revwallet/actions/workflows/publish-chart.yaml/badge.svg)
 ![Build](https://github.com/arthurjguerra/revwallet/actions/workflows/build.yaml/badge.svg)
 ![Tests](https://github.com/arthurjguerra/revwallet/actions/workflows/tests.yaml/badge.svg)
 [![Latest Release](https://img.shields.io/github/v/release/arthurjguerra/revwallet?include_prereleases)]([https://github.com/kubernetes/minikube/releases/latest](https://github.com/arthurjguerra/revwallet/releases/latest))


### PR DESCRIPTION
Adding a new badge to `README` to report the status of the Publish Helm Charts workflow.