### PR TITLE
Set same version for chart and image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,13 +51,19 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           new_revwallet_api_tag="${{ steps.get_tag.outputs.tag }}"
-          sed -i "s|tag:.*|tag: \"$new_revwallet_api_tag\"|" charts/revwallet-api/values.yaml
+
+          echo "Set the RevWallet API image tag to $new_revwallet_api_tag in Helm values.yaml"
+          sed -i "s|tag:.*|tag: $new_revwallet_api_tag|" charts/revwallet-api/values.yaml
+
+          echo "Set RevWallet API Chart version to $new_revwallet_api_tag"
+          sed -i "s|version:.*|version: $new_revwallet_api_tag|" charts/revwallet-api/Chart.yaml
 
       - name: Create Pull Request
+        if: startsWith(github.ref, 'refs/tags/')
         id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: set api image in Helm to ${{ steps.get_tag.outputs.tag }}
+          commit-message: set api image in helm to ${{ steps.get_tag.outputs.tag }}
           branch: api-image-update-${{ steps.get_tag.outputs.tag }}
           delete-branch: true
           title: 'RevWallet API image update to ${{ steps.get_tag.outputs.tag }} in Helm'

--- a/charts/revwallet-api/Chart.yaml
+++ b/charts/revwallet-api/Chart.yaml
@@ -3,5 +3,5 @@ name: revwallet-api
 description: RevWallet Helm Chart
 
 type: application
-version: 0.0.1
+version: 0.5.1
 appVersion: "latest"


### PR DESCRIPTION
For simplicity, the RevWallet API Chart and the RevWallet API docker image will be versioned with the same tag. Meaning that once a new tag is created in the repo, it will:

- Automatically set the version of the chart to this new tag
- Automatically set the image to this new tag