### PR TITLE
Publish charts when charts change

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'charts/**'
 
 jobs:
   publish:


### PR DESCRIPTION
Instead of triggering the Publish Chart workflow on every merge to `main`, it will be triggered on every merge + every merge that contains a change to the `charts` folder.