### PR TITLE
Add tests as part of build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,12 +9,8 @@ concurrency:
   group: ${{ github.workflow }}
 
 jobs:
-  tests:
-    secrets: inherit
-    uses: ./.github/workflows/tests.yaml
 
   build:
-    needs: tests
     runs-on: ubuntu-latest
 
     steps:
@@ -42,11 +38,17 @@ jobs:
         run: |
           new_revwallet_api_tag="${{ steps.get_tag.outputs.tag }}"
 
-          echo "Set the RevWallet API image tag to $new_revwallet_api_tag in Helm values.yaml"
+          echo "Set the RevWallet API image tag to $new_revwallet_api_tag in values.yaml"
+          sed -i "s|tag:.*|tag: $new_revwallet_api_tag|" helm/revwallet-api/values.yaml
+
+          echo "Set the RevWallet API image tag to $new_revwallet_api_tag in Chart values.yaml"
           sed -i "s|tag:.*|tag: $new_revwallet_api_tag|" charts/revwallet-api/values.yaml
 
           echo "Set RevWallet API Chart version to $new_revwallet_api_tag"
           sed -i "s|version:.*|version: $new_revwallet_api_tag|" charts/revwallet-api/Chart.yaml
+  
+      - name: Tests
+        uses: ./.github/workflows/tests.yaml
 
       - name: Create Pull Request
         id: create-pr

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,13 +18,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push images (main)
+      - name: Build and push image for PR
         uses: docker/build-push-action@v6
         with:
-          push: true
+          push: false
           tags: arthurjguerra18/revwallet:${{ github.sha }}
   
   tests:
     needs: build
     secrets: inherit
     uses: ./.github/workflows/tests.yaml
+    with:
+      is_ci: true
+      image_tag: ${{ github.sha }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,15 @@ name: Tests
 
 on:
   workflow_call:
+    inputs:
+      is_ci:
+        type: boolean
+        required: false
+        default: false
+      image_tag:
+        type: string
+        required: false
+        default: 'latest'
 
 jobs:
   tests-compose:
@@ -45,11 +54,12 @@ jobs:
           pip install pipenv
 
       - name: Use the image built in CI for testing
+        if: inputs.is_ci == true
         run: |
-          GITHUB_SHA=$(git rev-parse HEAD)
+          TAG=$${{ inputs.image_tag }}
 
-          echo "Updating helm chart with new image tag $GITHUB_SHA"
-          sed -i "s|tag:.*|tag: ${GITHUB_SHA}|" helm/revwallet-api/values.yaml
+          echo "Updating helm chart with new image tag $TAG"
+          sed -i "s|tag:.*|tag: ${TAG}|" helm/revwallet-api/values.yaml
 
       - name: Deploy API in K8s
         run: make create deploy

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ nginx:
 
 	$(MAKE) stop-port-forward
 
+	sleep 45
 	kubectl describe pod -l app=revwallet-api
 
 	kubectl -n revwallet-dev wait --timeout=5m --for=condition=Ready pod -l app=revwallet-api

--- a/helm/revwallet-api/values.yaml
+++ b/helm/revwallet-api/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: arthurjguerra18/revwallet
-  tag: v0.5.0
+  tag: v0.7.0
   
 env:
   DB_USERNAME: revwallet


### PR DESCRIPTION
Before, the workflow was testing a version that wasn't matching the version that triggered the `build` workflow. Now, the tests run after changing the Helm Chart with the correct image version.