### PR TITLE
Run tests before publishing chart

### DIFF
--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -8,6 +8,9 @@ on:
       - 'charts/**'
 
 jobs:
+  tests-k8s:
+    uses: ./.github/workflows/k8s-tests.yaml
+  
   publish:
     runs-on: ubuntu-latest
 
@@ -17,11 +20,23 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        id: python
+        uses: actions/setup-python@v5
         with:
-          fetch-depth: 0
-  
-      - name: Tests K8s
-        uses: ./.github/workflows/k8s-tests.yaml
+          python-version: '3.11'
+
+      - name: Install pipenv
+        run: |
+          pip install pipenv
+
+      - name: Deploy RevWallet 
+        run:
+          make create deploy
+      
+      - name: Run tests for K8s
+        run: make tests
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Before publishing a new Helm Chart for the RevWallet API, we need to properly run tests in K8s.