### PR TITLE
Ignore compose ci for helm changes

### DIFF
--- a/.github/workflows/compose-ci.yaml
+++ b/.github/workflows/compose-ci.yaml
@@ -7,6 +7,7 @@ on:
       - 'docs/**'
       - 'img/**'
       - 'charts/**'
+      - 'helm/**'
 
 jobs:
   tests-compose:


### PR DESCRIPTION
Docker Compose CI doesn't need to run if the code changes happen in `helm/**`.