### PR TITLE
Fix helm releaser checkout ref

### DIFF
--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -15,8 +15,17 @@ jobs:
       contents: write # to push chart release and create a release (helm/chart-releaser-action)
 
     steps:
+      - name: Get Latest Tag
+        id: get_latest_tag
+        run: |
+          echo "Fetching the latest tag of the repository..."
+          latest_tag=$(git describe --tags --abbrev=0)
+          echo "Latest Tag: ${latest_tag}"
+          echo "latest_tag=${latest_tag}" >> $GITHUB_OUTPUT
+
       - name: Checkout Code
         uses: actions/checkout@v4
+        ref: ${{ steps.get_latest_tag.outputs.latest_tag }}
 
       - name: Set up Python
         id: python


### PR DESCRIPTION
The Publish Helm Chart workflow was checking out the latest commit after the release. The problem is that checking out that reference was making the Helm Chart Releaser not notice changes in the chart. 

Now, it will checkout the latest tag, which is the reference that builds a new image and triggers a chart version & image upgrade. As a result, it will be able to detect changes and publish a new version of the chart.