### PR TITLE
feat: deploy branch chart in chart ci

### DIFF
--- a/.github/workflows/chart-ci.yaml
+++ b/.github/workflows/chart-ci.yaml
@@ -4,9 +4,10 @@ on:
   pull_request:
     paths:
       - 'charts/**'
+      - '.github/workflows/chart-ci.yaml'
 
 jobs:
-  tests-k8s:
+  chart-ci:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +24,18 @@ jobs:
         run: |
           pip install pipenv
 
-      - name: Deploy API in K8s (CD)
-        run: make create deploy
+      - name: Create K8s clusters
+        run: make create 
+        
+      - name: Deploy Services
+        run: make db prometheus alloy loki grafana
+
+      - name: Deploy RevWallet API (chart from current branch)
+        run: |
+          helm -n revwallet-dev install --values helm/revwallet-api/values.yaml revwallet-api charts/revwallet-api
+          
+      - name: Deploy Nginx
+        run: make nginx
 
       - name: Run tests for K8s
         run: make tests

--- a/.github/workflows/compose-ci.yaml
+++ b/.github/workflows/compose-ci.yaml
@@ -8,6 +8,7 @@ on:
       - 'img/**'
       - 'charts/**'
       - 'helm/**'
+      - '.github/workflows/charts-ci.yaml'
 
 jobs:
   tests-compose:

--- a/.github/workflows/k8s-ci.yaml
+++ b/.github/workflows/k8s-ci.yaml
@@ -7,6 +7,7 @@ on:
       - 'docs/**'
       - 'img/**'
       - 'charts/**'
+      - '.github/workflows/charts-ci.yaml'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
The `chart-ci` workflow was deploying the latest version of the published chart, now it deploys the chart from the current branch. This reflects in more meaningful CI tests, as the test suite runs against the changes proposed in the PR.