### PR TITLE
feat: read db creds from k8s secrets

### DIFF
--- a/charts/revwallet-api/templates/deployment.yaml
+++ b/charts/revwallet-api/templates/deployment.yaml
@@ -38,13 +38,25 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: DB_USERNAME
-              value: {{ .Values.env.DB_USERNAME }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentials.secret }}
+                  key: {{ .Values.credentials.dbUsernameSecretKey }}
             - name: DB_PASSWORD
-              value: {{ .Values.env.DB_PASSWORD }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentials.secret }}
+                  key: {{ .Values.credentials.dbPasswordSecretKey }}
             - name: DB_NAME
-              value: {{ .Values.env.DB_NAME }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentials.secret }}
+                  key: {{ .Values.credentials.dbNameSecretKey }}
             - name: DB_HOST
-              value: {{ .Values.env.DB_HOST }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.credentials.secret }}
+                  key: {{ .Values.credentials.dbHostSecretKey }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/revwallet-api/values.yaml
+++ b/charts/revwallet-api/values.yaml
@@ -9,6 +9,13 @@ imagePullSecrets: []
 nameOverride: "revwallet-api"
 fullnameOverride: "revwallet-api"
 
+credentials:
+  secret: revwallet-db
+  dbUsernameSecretKey: dbuser
+  dbPasswordSecretKey: dbpassword
+  dbNameSecretKey: dbname
+  dbHostSecretKey: dbhost
+
 env:
   DB_USERNAME: revwallet
   DB_PASSWORD: mypassword

--- a/charts/revwallet-api/values.yaml
+++ b/charts/revwallet-api/values.yaml
@@ -16,12 +16,6 @@ credentials:
   dbNameSecretKey: dbname
   dbHostSecretKey: dbhost
 
-env:
-  DB_USERNAME: revwallet
-  DB_PASSWORD: mypassword
-  DB_NAME: revwallet
-  DB_HOST: revwallet-db
-
 serviceAccount:
   create: true
   automount: true


### PR DESCRIPTION
The RevWallet deployment in the Helm Chart now reads DB credentials from k8s secrets instead of reading them directly from the deployment file. The credentials continue to be exported to the RevWallet API as environment variables, so no changes in the behaviour of the app.