### PR TITLE
feat: rename make targets to local

### DIFF
--- a/.github/workflows/chart-ci.yaml
+++ b/.github/workflows/chart-ci.yaml
@@ -25,17 +25,17 @@ jobs:
           pip install pipenv
 
       - name: Create K8s clusters
-        run: make create 
+        run: make local-create 
         
       - name: Deploy Services
-        run: make db prometheus alloy loki grafana
+        run: make local-db local-prometheus local-alloy local-loki local-grafana
 
       - name: Deploy RevWallet API (chart from current branch)
         run: |
           helm -n revwallet-dev install --values helm/revwallet-api/values.yaml revwallet-api charts/revwallet-api
           
       - name: Deploy Nginx
-        run: make nginx
+        run: make local-nginx
 
       - name: Run tests for K8s
         run: make tests

--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Deploy RevWallet 
         run:
-          make create deploy
+          make local-create local-deploy
       
       - name: Run tests for K8s
         run: make tests

--- a/.github/workflows/k8s-ci.yaml
+++ b/.github/workflows/k8s-ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Deploy RevWallet Dependencies in K8s
         run:
-          make create db prometheus alloy loki grafana
+          make local-create local-db local-prometheus local-alloy local-loki local-grafana
       
       - name: Deploy API in K8s with new image tag ${{ github.sha }}
         run: |
@@ -51,7 +51,7 @@ jobs:
           helm -n revwallet-dev install --values helm/revwallet-api/values.yaml --set image.tag=${GITHUB_SHA} revwallet-api revwallet-api/revwallet-api
       
       - name: Deploy Reverse Proxy in K8s
-        run: make nginx
+        run: make local-nginx
 
       - name: Run tests for K8s
         run: make tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pid
 
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,27 @@
 # Makefile to build and deploy RevWallet in K8s and Docker Compose
 
 .PHONY: \
-	nginx \
-	api \
-	db \
-	prometheus \
-	alloy \
-	loki \
-	grafana \
-	deploy \
-	delete-nginx \
-	delete-api \
-	delete-db \
-	delete-prometheus \
-	delete-alloy \
-	delete-loki \
-	delete-grafana \
-	delete \
+	local-nginx \
+	local-api \
+	local-db \
+	local-prometheus \
+	local-alloy \
+	local-loki \
+	local-grafana \
+	local-deploy \
+	local-delete-nginx \
+	local-delete-api \
+	local-delete-db \
+	local-delete-prometheus \
+	local-delete-alloy \
+	local-delete-loki \
+	local-delete-grafana \
+	local-delete \
 	compose-up \
 	compose-down \
-	create \
+	local-create \
 	setup-helm \
-	terminate \
+	local-terminate \
 	tests
 
 
@@ -41,7 +41,7 @@ compose-down:
 
 ################################ K8s Targets (Local) #################################
 
-create:
+local-create:
 	kind create cluster --name revwallet
 	kubectl create namespace revwallet-dev
 	kubectl config set-context kind-revwallet --namespace=revwallet-dev
@@ -54,47 +54,47 @@ setup-helm:
 	helm repo add revwallet-api https://arthurjguerra.github.io/revwallet
 	helm repo update
 
-terminate:
-	$(MAKE) delete
+local-terminate:
+	$(MAKE) local-delete
 	helm repo remove bitnami grafana prometheus-community
 	kind delete cluster --name revwallet
 
-deploy:
-	$(MAKE) db
-	$(MAKE) prometheus
-	$(MAKE) alloy
-	$(MAKE) loki
-	$(MAKE) grafana
-	$(MAKE) api
-	$(MAKE) nginx
+local-deploy:
+	$(MAKE) local-db
+	$(MAKE) local-prometheus
+	$(MAKE) local-alloy
+	$(MAKE) local-loki
+	$(MAKE) local-grafana
+	$(MAKE) local-api
+	$(MAKE) local-nginx
 
-db:
+local-db:
 	helm repo update
 	kubectl -n revwallet-dev apply -f helm/revwallet-db/secrets.yaml
 	helm -n revwallet-dev upgrade --install --values helm/revwallet-db/values.yaml revwallet-db bitnami/postgresql
 
-api:
+local-api:
 	kubectl -n revwallet-dev wait --timeout=5m --for=condition=Ready pod -l app=revwallet-db
 
 	helm repo update
 	helm -n revwallet-dev upgrade --install --values helm/revwallet-api/values.yaml revwallet-api revwallet-api/revwallet-api
 
-prometheus:
+local-prometheus:
 	helm repo update prometheus-community
 	helm -n revwallet-dev upgrade --install --values helm/prometheus/values.yaml prometheus prometheus-community/prometheus
 
-alloy:
+local-alloy:
 	kubectl -n revwallet-dev delete configmap alloy-config >/dev/null 2>&1 || true
 	kubectl -n revwallet-dev create configmap alloy-config --from-file=helm/alloy/config.alloy
 
 	helm repo update grafana
 	helm -n revwallet-dev upgrade --install --values helm/alloy/values.yaml alloy grafana/alloy
 
-loki:
+local-loki:
 	helm repo update grafana
 	helm -n revwallet-dev upgrade --install --values helm/loki/values.yaml loki grafana/loki-stack
 
-grafana:
+local-grafana:
 	kubectl -n revwallet-dev wait --timeout=5m --for=condition=Ready pod -l app=loki
 	kubectl -n revwallet-dev wait --timeout=5m --for=condition=Ready pod -l app=prometheus
 
@@ -104,7 +104,7 @@ grafana:
 	helm repo update grafana
 	helm -n revwallet-dev upgrade --install --values helm/grafana/values.yaml grafana grafana/grafana
 
-nginx:
+local-nginx:
 	$(MAKE) stop-port-forward
 
 	kubectl -n revwallet-dev wait --timeout=3m --for=condition=Ready pod -l app=revwallet-api
@@ -122,7 +122,7 @@ nginx:
 
 	$(MAKE) port-forward
 
-delete:
+local-delete:
 	$(MAKE) stop-port-forward
 	$(MAKE) delete-nginx 
 	$(MAKE) delete-api
@@ -132,30 +132,30 @@ delete:
 	$(MAKE) delete-loki
 	$(MAKE) delete-grafana
 
-delete-nginx:
+local-delete-nginx:
 	$(MAKE) stop-port-forward
 	kubectl -n revwallet-dev delete configmap nginx-conf >/dev/null 2>&1 || true
 	kubectl -n revwallet-dev delete configmap nginx-html >/dev/null 2>&1 || true
 	helm -n revwallet-dev uninstall nginx
 
-delete-alloy:
+local-delete-alloy:
 	helm -n revwallet-dev uninstall alloy
 	kubectl -n revwallet-dev delete configmap alloy-config
 
-delete-loki:
+local-delete-loki:
 	helm -n revwallet-dev uninstall loki
 
-delete-grafana:
+local-delete-grafana:
 	kubectl -n revwallet-dev delete configmap revwallet-dashboard >/dev/null 2>&1 || true
 	helm -n revwallet-dev uninstall grafana
 
-delete-prometheus:
+local-delete-prometheus:
 	helm -n revwallet-dev uninstall prometheus
 
-delete-api:
+local-delete-api:
 	helm -n revwallet-dev uninstall revwallet-api
 
-delete-db:
+local-delete-db:
 	kubectl -n revwallet-dev delete -f helm/revwallet-db/secrets.yaml
 	helm -n revwallet-dev uninstall revwallet-db
 
@@ -171,29 +171,29 @@ data:
 
 help:
 	@echo "RevWallet Makefile Usage:"
-	@echo "  make help                 - Display this help message."
-	@echo "  make create               - Create a local k8s cluster with kind."
-	@echo "  make deploy               - Deploy the API and all dependencies on k8s."
-	@echo "  make db                   - Deploy only the RevWallet database on k8s."
-	@echo "  make prometheus           - Deploy only Prometheus on k8s."
-	@echo "  make alloy                - Deploy only Alloy on k8s."
-	@echo "  make loki                 - Deploy only Loki on k8s."
-	@echo "  make grafana              - Deploy only Grafana on k8s."
-	@echo "  make api                  - Deploy only the RevWallet API on k8s."
-	@echo "  make nginx                - Deploy only Nginx on k8s."
-	@echo "  make test                 - Run the tests."
-	@echo "  make data                 - Generate sample data."
-	@echo "  make compose-up           - Start RevWallet API and dependencies with Docker Compose."
-	@echo "  make compose-down         - Stop RevWallet API and dependencies with Docker Compose."
-	@echo "  make terminate            - Delete all the running pods and terminate the k8s cluster."
-	@echo "  make port-forward         - Start port forwarding to Nginx."
-	@echo "  make stop-port-forward    - Stop port forwarding to Nginx."
-	@echo "  make setup-helm           - Install Helm repositories."
-	@echo "  make delete               - Delete the RevWallet API and all dependencies on k8s."
-	@echo "  make delete-db            - Delete only the RevWallet DB on k8s."
-	@echo "  make delete-prometheus    - Delete only Prometheus on k8s."
-	@echo "  make delete-alloy         - Delete only Alloy on k8s."
-	@echo "  make delete-loki          - Delete only Loki on k8s."
-	@echo "  make delete-grafana       - Delete only Grafana on k8s."
-	@echo "  make delete-api           - Delete only the RevWallet API on k8s."
-	@echo "  make delete-nginx         - Delete only Nginx deployment on k8s."
+	@echo "  make help                    - Display this help message."
+	@echo "  make local-create            - Create a local k8s cluster with kind."
+	@echo "  make local-deploy            - Deploy the API and all dependencies on k8s."
+	@echo "  make local-db                - Deploy only the RevWallet database on k8s."
+	@echo "  make local-prometheus        - Deploy only Prometheus on k8s."
+	@echo "  make local-alloy             - Deploy only Alloy on k8s."
+	@echo "  make local-loki              - Deploy only Loki on k8s."
+	@echo "  make local-grafana           - Deploy only Grafana on k8s."
+	@echo "  make local-api               - Deploy only the RevWallet API on k8s."
+	@echo "  make local-nginx             - Deploy only Nginx on k8s."
+	@echo "  make test                    - Run the tests."
+	@echo "  make data                    - Generate sample data."
+	@echo "  make compose-up              - Start RevWallet API and dependencies with Docker Compose."
+	@echo "  make compose-down            - Stop RevWallet API and dependencies with Docker Compose."
+	@echo "  make local-terminate         - Delete all the running pods and terminate the k8s cluster."
+	@echo "  make port-forward            - Start port forwarding to Nginx."
+	@echo "  make stop-port-forward       - Stop port forwarding to Nginx."
+	@echo "  make setup-helm              - Install Helm repositories."
+	@echo "  make local-delete            - Delete the RevWallet API and all dependencies on k8s."
+	@echo "  make local-delete-db         - Delete only the RevWallet DB on k8s."
+	@echo "  make local-delete-prometheus - Delete only Prometheus on k8s."
+	@echo "  make local-delete-alloy      - Delete only Alloy on k8s."
+	@echo "  make local-delete-loki       - Delete only Loki on k8s."
+	@echo "  make local-delete-grafana    - Delete only Grafana on k8s."
+	@echo "  make local-delete-api        - Delete only the RevWallet API on k8s."
+	@echo "  make local-delete-nginx      - Delete only Nginx deployment on k8s."


### PR DESCRIPTION
This PR simply rename existing `Makefile` targets by appending the prefix `local-`. This will improve the semantics of the `Makefile` to reflect exactly where the targets will rollout or delete resources.