### PR TITLE
Restrict CI to dependabot and myuser

### DIFF
--- a/.github/workflows/local-k8s-ci.yaml
+++ b/.github/workflows/local-k8s-ci.yaml
@@ -1,7 +1,7 @@
 name: Local K8s CI
 
 on:
-  pull_request:
+  pull_request_target:
     paths-ignore:
       - 'README.md'
       - 'docs/**'
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build-and-test:
+    if: github.action == 'dependabot[bot]' || github.actor == 'arthurjguerra'
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Hub

--- a/.github/workflows/local-k8s-ci.yaml
+++ b/.github/workflows/local-k8s-ci.yaml
@@ -1,4 +1,4 @@
-name: Local K8s CI
+name: Local K8s CI (by @${{ github.actor }})
 
 on:
   pull_request_target:


### PR DESCRIPTION
## Summary
This PR allows dependabot to open PRs and have CI run successfully. For security purposes, CI was also restricted to be run by the dependabot user and myself.